### PR TITLE
Removed network from Hemi texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hemi Connector
 
-Hemi Connector was developed using Domain-Driven Design (DDD) principles to facilitate interaction with the Hemi network and external services. This document provides instructions for setting up, running, and contributing to the project.
+Hemi Connector was developed using Domain-Driven Design (DDD) principles to facilitate interaction with Hemi and external services. This document provides instructions for setting up, running, and contributing to the project.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hemiconnector",
   "version": "1.0.0",
-  "description": "Application to connect Hemi Network to External Services",
+  "description": "Application to connect Hemi to External Services",
   "license": "MIT",
   "author": "Thomas Alvarenga <thomas@hemi.xyz>",
   "main": "dist/index.js",


### PR DESCRIPTION
### Description

Fixed the name of the network to be just Hemi.

### Related issue(s)

Closes https://github.com/hemilabs/HemiConnector/issues/9